### PR TITLE
Fixes #38 Set theme_name variable to use for settings

### DIFF
--- a/theme-settings.php
+++ b/theme-settings.php
@@ -11,7 +11,7 @@ function bootstrap_lite_form_system_theme_settings_alter(&$form, &$form_state, $
   if (isset($form_id)) {
     return;
   }
-
+  $theme_name = $form['theme']['#value'];
   $form['bootstrap'] = array(
     '#type' => 'vertical_tabs',
     '#prefix' => '<h2><small>' . t('Bootstrap Settings') . '</small></h2>',
@@ -23,7 +23,7 @@ function bootstrap_lite_form_system_theme_settings_alter(&$form, &$form_state, $
   $default_theme_details = array(
     'name' => t('Default'),
     'description' => t('Pure Bootstrap CSS'),
-    'thumbnail' => base_path() . backdrop_get_path('theme', 'bootstrap_lite') . '/preview.jpg',
+    'thumbnail' => base_path() . backdrop_get_path('theme', $theme_name) . '/preview.jpg',
   );
 
   $bootswatch_themes[''] = bootstrap_bootswatch_template($default_theme_details);
@@ -51,7 +51,7 @@ function bootstrap_lite_form_system_theme_settings_alter(&$form, &$form_state, $
 
   $form['bootswatch']['bootstrap_lite_bootswatch'] = array(
     '#type' => 'radios',
-    '#default_value' => theme_get_setting('bootstrap_lite_bootswatch', 'bootstrap_lite'),
+    '#default_value' => theme_get_setting('bootstrap_lite_bootswatch', $theme_name),
     '#options' => $bootswatch_themes,
     '#empty_option' => t('Disabled'),
     '#empty_value' => NULL,
@@ -74,7 +74,7 @@ function bootstrap_lite_form_system_theme_settings_alter(&$form, &$form_state, $
     '#type' => 'select',
     '#title' => t('Navbar Position'),
     '#description' => t('Select your Navbar position.'),
-    '#default_value' => theme_get_setting('bootstrap_lite_navbar_position', 'bootstrap_lite'),
+    '#default_value' => theme_get_setting('bootstrap_lite_navbar_position', $theme_name),
     '#options' => array(
       'static-top' => t('Static Top'),
       'fixed-top' => t('Fixed Top'),
@@ -87,7 +87,7 @@ function bootstrap_lite_form_system_theme_settings_alter(&$form, &$form_state, $
     '#type' => 'select',
     '#title' => t('Navbar Menu Position'),
     '#description' => t('Select your Navbar Menu position.'),
-    '#default_value' => theme_get_setting('bootstrap_lite_navbar_menu_position', 'bootstrap_lite'),
+    '#default_value' => theme_get_setting('bootstrap_lite_navbar_menu_position', $theme_name),
     '#options' => array(
       'navbar-left' => t('Left'),
       'navbar-right' => t('Right'),
@@ -99,14 +99,14 @@ function bootstrap_lite_form_system_theme_settings_alter(&$form, &$form_state, $
     '#type' => 'checkbox',
     '#title' => t('Inverse navbar style'),
     '#description' => t('Select if you want the inverse navbar style.'),
-    '#default_value' => theme_get_setting('bootstrap_lite_navbar_inverse', 'bootstrap_lite'),
+    '#default_value' => theme_get_setting('bootstrap_lite_navbar_inverse', $theme_name),
   );
 
   $form['navbar']['bootstrap_lite_navbar_user_menu'] = array(
     '#type' => 'checkbox',
     '#title' => t('Add cog with user-menu'),
     '#description' => t('Select if you want cog style right pulled popup menu.'),
-    '#default_value' => theme_get_setting('bootstrap_lite_navbar_user_menu', 'bootstrap_lite'),
+    '#default_value' => theme_get_setting('bootstrap_lite_navbar_user_menu', $theme_name),
   );
 
   $form['breadcrumbs'] = array(
@@ -119,13 +119,13 @@ function bootstrap_lite_form_system_theme_settings_alter(&$form, &$form_state, $
   $form['breadcrumbs']['bootstrap_lite_breadcrumb_home'] = array(
     '#type' => 'checkbox',
     '#title' => t('Show "Home" breadcrumb link'),
-    '#default_value' => theme_get_setting('bootstrap_lite_breadcrumb_home', 'bootstrap_lite'),
+    '#default_value' => theme_get_setting('bootstrap_lite_breadcrumb_home', $theme_name),
     '#description' => t('If your site has a module dedicated to handling breadcrumbs already, ensure this setting is enabled.'),
   );
   $form['breadcrumbs']['bootstrap_lite_breadcrumb_title'] = array(
     '#type' => 'checkbox',
     '#title' => t('Show current page title at end'),
-    '#default_value' => theme_get_setting('bootstrap_lite_breadcrumb_title', 'bootstrap_lite'),
+    '#default_value' => theme_get_setting('bootstrap_lite_breadcrumb_title', $theme_name),
     '#description' => t('If your site has a module dedicated to handling breadcrumbs already, ensure this setting is disabled.'),
   );
 
@@ -138,7 +138,7 @@ function bootstrap_lite_form_system_theme_settings_alter(&$form, &$form_state, $
   $form['tweaks']['bootstrap_lite_container'] = array(
     '#type' => 'select',
     '#title' => t('Container type'),
-    '#default_value' => theme_get_setting('bootstrap_lite_container', 'bootstrap_lite'),
+    '#default_value' => theme_get_setting('bootstrap_lite_container', $theme_name),
     '#description' => t('Switch between full width (fluid) or fixed (max 1170px) width.'),
     '#options' => array(
       'container' => t('Fixed'),
@@ -149,7 +149,7 @@ function bootstrap_lite_form_system_theme_settings_alter(&$form, &$form_state, $
   $form['tweaks']['bootstrap_lite_datetime'] = array(
     '#type' => 'checkbox',
     '#title' => t('Show "XX time ago".'),
-    '#default_value' => theme_get_setting('bootstrap_lite_datetime', 'bootstrap_lite'),
+    '#default_value' => theme_get_setting('bootstrap_lite_datetime', $theme_name),
     '#description' => t('If enabled, replace date output for nodes and comments by "XX time ago".'),
   );
 
@@ -180,7 +180,7 @@ function bootstrap_lite_form_system_theme_settings_alter(&$form, &$form_state, $
       '3.4.0',
       '3.4.1',
     )),
-    '#default_value' => theme_get_setting('bootstrap_lite_cdn', 'bootstrap_lite'),
+    '#default_value' => theme_get_setting('bootstrap_lite_cdn', $theme_name),
     '#empty_option' => t('Disabled'),
     '#empty_value' => NULL,
   );
@@ -192,7 +192,7 @@ function bootstrap_lite_form_system_theme_settings_alter(&$form, &$form_state, $
       '4.4.0',
       '4.7.0',
     )),
-    '#default_value' => theme_get_setting('bootstrap_lite_font_awesome', 'bootstrap_lite'),
+    '#default_value' => theme_get_setting('bootstrap_lite_font_awesome', $theme_name),
     '#empty_option' => t('Disabled'),
     '#empty_value' => NULL,
   );

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -23,7 +23,7 @@ function bootstrap_lite_form_system_theme_settings_alter(&$form, &$form_state, $
   $default_theme_details = array(
     'name' => t('Default'),
     'description' => t('Pure Bootstrap CSS'),
-    'thumbnail' => base_path() . backdrop_get_path('theme', $theme_name) . '/preview.jpg',
+    'thumbnail' => base_path() . backdrop_get_path('theme', 'bootstrap_lite') . '/preview.jpg',
   );
 
   $bootswatch_themes[''] = bootstrap_bootswatch_template($default_theme_details);

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -23,7 +23,7 @@ function bootstrap_lite_form_system_theme_settings_alter(&$form, &$form_state, $
   $default_theme_details = array(
     'name' => t('Default'),
     'description' => t('Pure Bootstrap CSS'),
-    'thumbnail' => base_path() . backdrop_get_path('theme', 'bootstrap_lite') . '/preview.jpg',
+    'thumbnail' => base_path() . backdrop_get_path('theme', $theme_name) . '/preview.jpg',
   );
 
   $bootswatch_themes[''] = bootstrap_bootswatch_template($default_theme_details);


### PR DESCRIPTION
To Fix #38 
Added a variable of $theme_name and used it wherever 'bootstrap_lite' was referred to as the settings in theme_get_setting functions.
Not line 26 ' 'thumbnail' => base_path() . backdrop_get_path('theme', 'bootstrap_lite') . '/preview.jpg','
or line 156 'backdrop_add_css(backdrop_get_path('theme', 'bootstrap_lite') . '/css/settings.css');' 
Now I didn't feel a need to override settings.css so hadn't created a version and as is admin screen is not part of the main bit of the theme use.