### PR TITLE
Added form-control for email element in webform.

### DIFF
--- a/template.php
+++ b/template.php
@@ -311,7 +311,7 @@ function bootstrap_lite_email($variables) {
  *
  * @ingroup themeable
  */
-function bootstrap5_lite_webform_email($variables) {
+function bootstrap_lite_webform_email($variables) {
   $variables['element']['#attributes']['class'][] = 'form-control';
   return theme_webform_email($variables);
 }

--- a/template.php
+++ b/template.php
@@ -301,6 +301,22 @@ function bootstrap_lite_email($variables) {
 }
 
 /**
+ * Returns HTML for an email form element in a webform.
+ *
+ * @param $variables
+ *   An associative array containing:
+ *   - element: An associative array containing the properties of the element.
+ *     Properties used: #title, #value, #description, #size, #maxlength,
+ *     #placeholder, #required, #attributes, #autocomplete_path.
+ *
+ * @ingroup themeable
+ */
+function bootstrap5_lite_webform_email($variables) {
+  $variables['element']['#attributes']['class'][] = 'form-control';
+  return theme_webform_email($variables);
+}
+
+/**
  * Returns HTML for a textfield form element.
  *
  * @param $variables


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/bootstrap_lite/issues/44.

The webform email element needs an additional theme call to add the form-control class.