### PR TITLE
Issue #56: Add class=“img-responsive” option for images.

### DIFF
--- a/css/overrides.css
+++ b/css/overrides.css
@@ -141,7 +141,7 @@ a.fieldset-title:hover {
 
 /* Fix drop button style in admin area. */
 .dropbutton .dropbutton-action > * {
-  padding: 6px 12px;  
+  padding: 6px 12px;
 }
 
 .dropbutton .dropbutton-action a,
@@ -203,7 +203,7 @@ ul.action-links i.fa {
 
 #views-ui-preview-form > div > div,
 #views-ui-preview-form > div > input {
-  float: none;  
+  float: none;
 }
 
 .views-display-columns > * {
@@ -234,7 +234,7 @@ h1.page-title {
 /* Style user pic. */
 .user-picture img {
   border: 1px solid #e5e7e8;
-  padding: 1px; 
+  padding: 1px;
 }
 
 /* Style nodes and coments in twitter style. */
@@ -291,7 +291,7 @@ span.password-toggle-wrapper {
 
 /* Fixes a conflict between Bootstrap and the admin bar */
 
-#admin-bar .dropdown li > a, 
+#admin-bar .dropdown li > a,
 #admin-bar .dropdown li > span {
   margin-bottom: 0;
 }

--- a/js/theme-settings.js
+++ b/js/theme-settings.js
@@ -1,0 +1,43 @@
+(function ($, Backdrop) {
+  /*global jQuery:false */
+  /*global Backdrop:false */
+  "use strict";
+
+  /**
+   * Provide vertical tab summaries for Bootstrap settings.
+   */
+  Backdrop.behaviors.bootstrapLiteSettingSummaries = {
+    attach: function (context) {
+      var $context = $(context);
+
+      // Version and CDN [TODO]
+
+      // Bootswatch theme [TODO]
+
+      // Navbar [TODO]
+
+      // Breadcrumbs [TODO]
+
+      // Tweaks
+
+      $context.find('#edit-tweaks').backdropSetSummary(function () {
+        var summary = [];
+
+        var container_type = 'Container type: ' + $context.find('select[name="bootstrap_lite_container"] :selected').text();
+        summary.push(container_type);
+
+        if ($context.find(':input[name="bootstrap_lite_datetime"]').is(':checked')) {
+          summary.push(Backdrop.t('Show "XX time ago"'));
+        }
+
+        if ($context.find(':input[name="bootstrap_lite_image_responsive"]').is(':checked')) {
+          summary.push(Backdrop.t('Responsive images'));
+        }
+
+        return summary.join('<br>');
+      });
+
+    }
+  };
+
+})(jQuery, Backdrop);

--- a/js/theme-settings.js
+++ b/js/theme-settings.js
@@ -10,30 +10,69 @@
     attach: function (context) {
       var $context = $(context);
 
-      // Version and CDN [TODO]
+      // Version and CDN
 
-      // Bootswatch theme [TODO]
+      $context.find('#edit-bootstrap-lite-cdn').backdropSetSummary(function () {
+        var summary = [];
+        var bootstrap_version = 'Bootstrap: ' + $context.find('select[name="bootstrap_lite_cdn"] :selected').text();
+        summary.push(bootstrap_version);
+        var fontawesome_version = 'FontAwesome: ' + $context.find('select[name="bootstrap_lite_font_awesome"] :selected').text();
+        summary.push(fontawesome_version);
+        return summary.join('<br>');
+      });
 
-      // Navbar [TODO]
+      // Bootswatch theme
 
-      // Breadcrumbs [TODO]
+      $context.find('#edit-bootswatch').backdropSetSummary(function () {
+        var bootswatch = $context.find('#edit-bootstrap-lite-bootswatch input[checked="checked"]').parent().find('h3').text();
+        if (bootswatch == '') {
+          bootswatch = Backdrop.t('Default');
+        }
+        return bootswatch;
+      });
+
+      // Navbar
+
+      $context.find('#edit-navbar').backdropSetSummary(function () {
+        var summary = [];
+        var navbar_position = 'Position: ' + $context.find('select[name="bootstrap_lite_navbar_position"] :selected').text();
+        summary.push(navbar_position);
+        var menu_position = 'Menu position: ' + $context.find('select[name="bootstrap_lite_navbar_menu_position"] :selected').text();
+        summary.push(menu_position);
+        if ($context.find(':input[name="bootstrap_lite_navbar_inverse"]').is(':checked')) {
+          summary.push(Backdrop.t('Inverse navbar'));
+        }
+        if ($context.find(':input[name="bootstrap_lite_navbar_user_menu"]').is(':checked')) {
+          summary.push(Backdrop.t('Cog style'));
+        }
+        return summary.join('<br>');
+      });
+
+      // Breadcrumbs
+
+      $context.find('#edit-breadcrumbs').backdropSetSummary(function () {
+        var summary = [];
+        if ($context.find(':input[name="bootstrap_lite_breadcrumb_home"]').is(':checked')) {
+          summary.push(Backdrop.t('Show home'));
+        }
+        if ($context.find(':input[name="bootstrap_lite_breadcrumb_title"]').is(':checked')) {
+          summary.push(Backdrop.t('Show current page'));
+        }
+        return summary.join('<br>');
+      });
 
       // Tweaks
 
       $context.find('#edit-tweaks').backdropSetSummary(function () {
         var summary = [];
-
         var container_type = 'Container type: ' + $context.find('select[name="bootstrap_lite_container"] :selected').text();
         summary.push(container_type);
-
         if ($context.find(':input[name="bootstrap_lite_datetime"]').is(':checked')) {
           summary.push(Backdrop.t('Show "XX time ago"'));
         }
-
         if ($context.find(':input[name="bootstrap_lite_image_responsive"]').is(':checked')) {
           summary.push(Backdrop.t('Responsive images'));
         }
-
         return summary.join('<br>');
       });
 

--- a/template.php
+++ b/template.php
@@ -967,3 +967,13 @@ function bootstrap_lite_preprocess_node(&$variables){
     $variables['timeago'] = t('@time ago', array('@time' => format_interval(time() - $node->created)));
   }
 }
+
+/**
+ * Implements hook_preprocess_image().
+ */
+function bootstrap_lite_preprocess_image(&$variables) {
+  // Add responsiveness, if necessary.
+  if (theme_get_setting('bootstrap_lite_image_responsive')) {
+    $variables['attributes']['class'][] = 'img-responsive';
+  }
+}

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -14,6 +14,9 @@ function bootstrap_lite_form_system_theme_settings_alter(&$form, &$form_state, $
   $theme_name = $form['theme']['#value'];
   $form['bootstrap'] = array(
     '#type' => 'vertical_tabs',
+    '#attached' => array(
+      'js'  => array(backdrop_get_path('theme', 'bootstrap_lite') . '/js/theme-settings.js'),
+    ),
     '#prefix' => '<h2><small>' . t('Bootstrap Settings') . '</small></h2>',
     '#weight' => -10,
   );
@@ -205,6 +208,12 @@ function bootstrap_lite_form_system_theme_settings_alter(&$form, &$form_state, $
     '#description' => t('If enabled, replace date output for nodes and comments by "XX time ago".'),
   );
 
+  $form['tweaks']['bootstrap_lite_image_responsive'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Responsive images'),
+    '#default_value' => theme_get_setting('bootstrap_lite_image_responsive', $theme_name),
+    '#description' => t('Images in Bootstrap 3 can be made responsive-friendly via the addition of the <code>.img-responsive</code> class. This applies <code>max-width: 100%;</code> and <code>height: auto;</code> to the image so that it scales nicely to the parent element.'),
+  );
 }
 
 function bootstrap_bootswatch_template($bootswatch_theme){


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/bootstrap_lite/issues/56.