### PR TITLE
Issue #60: Initialize Bootswatch in .info file.

### DIFF
--- a/bootstrap_lite.info
+++ b/bootstrap_lite.info
@@ -6,6 +6,7 @@ type = theme
 tags[] = Bootstrap
 
 settings[bootstrap_lite_cdn] = 3.4.1
+settings[bootstrap_lite_bootswatch] = ""
 settings[bootstrap_lite_font_awesome] = 4.7.0
 settings[bootstrap_lite_container] = container
 settings[bootstrap_lite_navbar_position] = static-top


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/bootstrap_lite/issues/60.